### PR TITLE
fix broken UI caused by canva new design

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,6 +1,5 @@
 .buttonProofMe {
     padding-left: 10px !important;
-    margin-left: -3px !important;
     background: #6ac000 !important;
 }
 

--- a/src/js/send-to-proofme.js
+++ b/src/js/send-to-proofme.js
@@ -608,7 +608,7 @@ $( document ).ready( () =>  {
                             popupClosed = true
                         })
                         logger("popupClosed: ", popupClosed)
-                        if ($(".center").html() === "Your design is ready" && !popupClosed) {
+                        if ($(".center").html() === "Your design is ready and downloading" && !popupClosed) {
                             $(".buttonRedirect").remove()
                             let buttonsDom = []
                             const shareButtons = $(".shareButtons")

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "ProofMe for Canva",
   "description": "Create proofs from your designs without leaving Canva. Add the power of visual review to the world’s easiest design app.",
-  "version": "0.0.12",
+  "version": "0.0.13",
 
   "icons": {
       "16": "images/proofme-icon-chrome-store-16.png",


### PR DESCRIPTION
Hi,

I noticed canva pushed out a new design and broke injected proofme buttons. Looks like it's a one minute fix, here you go.